### PR TITLE
Bugfix for FieldListCommand.php

### DIFF
--- a/src/Commands/Field/FieldListCommand.php
+++ b/src/Commands/Field/FieldListCommand.php
@@ -47,7 +47,7 @@ class FieldListCommand extends PwConnector {
     // get available fields
     $fieldtypes = array();
     foreach (\ProcessWire\wire('modules') as $module) {
-      if (preg_match('/^Fieldtype/', $module->name)) {
+      if (preg_match('/^Fieldtype/', (string)$module->name)) {
         $fieldtypes[] = $module->name;
       }
     }
@@ -55,7 +55,7 @@ class FieldListCommand extends PwConnector {
     $headers = array('Name', 'Label', 'Type', 'Templates');
     $data = $this->getData($this->getFilter($input));
 
-    if (count($data->count) > 0) {
+    if ($data->count > 0) {
       foreach ($data->content as $tag => $c) {
         $tools->writeInfo('--- ' . strtoupper($tag) . ' ---');
         $tables = new Tables($output);


### PR DESCRIPTION
# Upstream PR notes — wirecli/wire-cli v1.4.13

Cursor found a bug and helpfully wrote a detailed note below:

Two small bugs found while running v1.4.13 against a ProcessWire 3.0.244 install on PHP 8.3. The first is a **hard blocker** for `field:list` (no command-line invocation succeeds), the second is a deprecation warning that becomes a fatal error on PHP 8.4.

Both have been patched locally in `/home/echo/.composer/vendor/wirecli/wire-cli/`. Patches will be lost by `composer global update` — re-apply if needed.

---

## Bug 1 — `field:list` always throws `TypeError`

**Severity:** Blocker — every invocation of `wirecli field:list` (with or without options) errors out before printing anything.

**Affected file:** `src/Commands/Field/FieldListCommand.php`

**Reproduce:**

```bash
cd /path/to/processwire-root
wirecli field:list
# or
wirecli field:list --all
wirecli field:list --type=Email
wirecli field:list --tag=foo
```

**Result on PHP 8.1+ / 8.3 / 8.4:**

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, int given
in src/Commands/Field/FieldListCommand.php:58
Stack trace:
#0 src/Commands/Field/FieldListCommand.php(58): count(99)
#1 vendor/symfony/console/Command/Command.php(326): …->execute(…)
…
```

**Cause:** `getData()` returns an object whose `->count` property is the **integer** total of matched fields:

```php
return (object) array('count' => $count, 'content' => $content);
```

…but `execute()` then does:

```php
if (count($data->count) > 0) {
```

`count()` on a scalar was a `WARNING` in PHP 7.2 and a `TypeError` since PHP 8.0, so this branch can never run.

**Fix (1-character logic change):**

```diff
-    if (count($data->count) > 0) {
+    if ($data->count > 0) {
```

(Or equivalently `if (!empty($data->content))`.)

**Verified after fix:**

```text
$ wirecli field:list | tail -2
(89 in set, total: 89)

$ wirecli field:list --all | tail -2
(99 in set, total: 99)

$ wirecli field:list --type=Email | tail -2
(1 in set, total: 1)
```

---

## Bug 2 — `preg_match()` deprecation when iterating modules

**Severity:** Deprecation warning under PHP 8.1+; promoted to a hard error in PHP 8.4 (`null` no longer auto-coerces to string for internal functions).

**Affected files (same one-character fix in each):**

- `src/Commands/Field/FieldListCommand.php:50`
- `src/Commands/Field/FieldTypesCommand.php:41`
- `src/Commands/Field/FieldCreateCommand.php:94`

**Reproduce:**

```bash
wirecli field:types
```

**Result:**

```
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string
is deprecated in src/Commands/Field/FieldTypesCommand.php on line 41
```

**Cause:** When iterating `\ProcessWire\wire('modules')` some module info entries (e.g. uninstalled placeholders) return `null` for `->name` rather than a string, and `preg_match()` can no longer accept `null`.

**Fix (cast to string):**

```diff
-      if (preg_match('/^Fieldtype/', $module->name)) {
+      if (preg_match('/^Fieldtype/', (string)$module->name)) {
```

Apply the same change to the three files above.

**Optional cleanup in `FieldListCommand`:** the `$fieldtypes` array (lines 48–53) is collected but never read anywhere in the file — likely dead code from an earlier revision. Worth removing in the same PR if you want, otherwise leave it (the cast above is enough to silence the deprecation).

---

## Environment

- wirecli `v1.4.13` (composer global, package `wirecli/wire-cli`)
- ProcessWire `3.0.244`
- PHP `8.3.x` (also reproduced reasoning under 8.4 behaviour)
- OS: Linux (RHEL 10 family)