### PR TITLE
Fix Field commands PHP 8 compatibility

### DIFF
--- a/src/Commands/Field/FieldCreateCommand.php
+++ b/src/Commands/Field/FieldCreateCommand.php
@@ -91,7 +91,7 @@ class FieldCreateCommand extends PwConnector {
     // get available fieldtypes
     $fieldtypes = array();
     foreach (\ProcessWire\wire('modules') as $module) {
-      if (preg_match('/^Fieldtype/', $module->name)) {
+      if (preg_match('/^Fieldtype/', (string)$module->name)) {
         $fieldtypes[] = $module->name;
       }
     }

--- a/src/Commands/Field/FieldListCommand.php
+++ b/src/Commands/Field/FieldListCommand.php
@@ -47,7 +47,7 @@ class FieldListCommand extends PwConnector {
     // get available fields
     $fieldtypes = array();
     foreach (\ProcessWire\wire('modules') as $module) {
-      if (preg_match('/^Fieldtype/', $module->name)) {
+      if (preg_match('/^Fieldtype/', (string)$module->name)) {
         $fieldtypes[] = $module->name;
       }
     }
@@ -55,7 +55,7 @@ class FieldListCommand extends PwConnector {
     $headers = array('Name', 'Label', 'Type', 'Templates');
     $data = $this->getData($this->getFilter($input));
 
-    if (count($data->count) > 0) {
+    if ($data->count > 0) {
       foreach ($data->content as $tag => $c) {
         $tools->writeInfo('--- ' . strtoupper($tag) . ' ---');
         $tables = new Tables($output);

--- a/src/Commands/Field/FieldTypesCommand.php
+++ b/src/Commands/Field/FieldTypesCommand.php
@@ -38,7 +38,7 @@ class FieldTypesCommand extends PwConnector {
 
     // get available fieldtypes
     foreach (\ProcessWire\wire('modules') as $module) {
-      if (preg_match('/^Fieldtype/', $module->name)) {
+      if (preg_match('/^Fieldtype/', (string)$module->name)) {
         $tools->writeDfList($module->name, substr($module->name, 9));
       }
     }


### PR DESCRIPTION
Addresses issues found in PRs 20, 21, and 22 related to the Field commands. The fixes resolve PHP 8 compatibility issues by adding explicit string casts for `preg_match` and removing an erroneous `count()` call on an integer.