### PR TITLE
🔒 Replace weak cryptographic functions for salt generation

### DIFF
--- a/src/Helpers/Installer.php
+++ b/src/Helpers/Installer.php
@@ -346,17 +346,8 @@ class Installer {
    * @param array $values
    */
   protected function dbSaveConfigFile(array $values) {
-    $file = __FILE__; 
-		$time = time();
-		$host = empty($values['httpHosts']) ? '' : implode(',', $values['httpHosts']);
-
-		if(function_exists('random_bytes')) {
-			$authSalt = sha1(random_bytes(random_int(40, 128)));
-			$tableSalt = sha1(random_int(0, 65535) . "$host$file$time"); 
-		} else {
-			$authSalt = md5(mt_rand() . microtime(true));
-			$tableSalt = md5(mt_rand() . "$host$file$time"); 
-		}
+		$authSalt = bin2hex(random_bytes(20));
+		$tableSalt = bin2hex(random_bytes(20));
 
     $cfg =  "\n/**" .
       "\n * Installer: Database Configuration" .


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of weak cryptographic functions (`md5`, `sha1`, `mt_rand`) and predictable data (timestamp, filename) to generate security salts in `src/Helpers/Installer.php`.

⚠️ **Risk:** If left unfixed, the generated `authSalt` and `tableSalt` could potentially be predicted or brute-forced, compromising the security of user authentication and other hashed data in the ProcessWire installation.

🛡️ **Solution:** The fix replaces the insecure generation logic with `bin2hex(random_bytes(20))`, which uses a cryptographically secure pseudo-random number generator (CSPRNG) to produce 40-character random hex strings. This ensures high entropy and unpredictability for the salts. Unneeded fallbacks and predictable entropy sources were removed.

---
*PR created automatically by Jules for task [1961918382625126282](https://jules.google.com/task/1961918382625126282) started by @flydev-fr*