### PR TITLE
🧹 fix: remove unused imports in CheatCommand

### DIFF
--- a/src/Commands/Common/CheatCommand.php
+++ b/src/Commands/Common/CheatCommand.php
@@ -1,11 +1,7 @@
 <?php namespace Wirecli\Commands\Common;
 
-use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Wirecli\Helpers\ProcessDiagnostics\DiagnoseImagehandling;
-use Wirecli\Helpers\ProcessDiagnostics\DiagnosePhp;
 use Wirecli\Helpers\PwConnector;
 use Wirecli\Helpers\WsTools as Tools;
 


### PR DESCRIPTION
🎯 **What:** Removed unused imports in `src/Commands/Common/CheatCommand.php`.
💡 **Why:** Removing dead code like unused imports cleans up the file and reduces cognitive load for developers, improving maintainability.
✅ **Verification:** Verified that the removed classes are not used in the file and performed a syntax check using `php -l`.
✨ **Result:** A cleaner `CheatCommand.php` file with only the necessary imports.

---
*PR created automatically by Jules for task [6519420306255101856](https://jules.google.com/task/6519420306255101856) started by @flydev-fr*