### PR TITLE
Use ZipArchive class for profile extraction in NewCommand

### DIFF
--- a/src/Commands/Common/NewCommand.php
+++ b/src/Commands/Common/NewCommand.php
@@ -15,6 +15,7 @@ use Wirecli\Helpers\Downloader;
 use Wirecli\Helpers\Installer;
 use Wirecli\Helpers\PwConnector;
 use Wirecli\Helpers\WsTools as Tools;
+use ZipArchive;
 
 /**
  * Class NewCommand
@@ -650,8 +651,15 @@ class NewCommand extends PWConnector {
 
     try {
       $extractPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid(time()) . DIRECTORY_SEPARATOR;
-      // TODO: use Symfony ZipArchive class
-      //$extractionSucceeded = $distill->extractWithoutRootDirectory($profile, $extractPath);
+      $this->fs->mkdir($extractPath);
+
+      $zip = new ZipArchive;
+      $extractionSucceeded = false;
+
+      if ($zip->open($profile) === TRUE) {
+        $extractionSucceeded = $zip->extractTo($extractPath);
+        $zip->close();
+      }
 
       foreach (new \DirectoryIterator($extractPath) as $fileInfo) {
         if ($fileInfo->isDir() && !$fileInfo->isDot()) {


### PR DESCRIPTION
This change replaces the commented-out zip extraction logic in `src/Commands/Common/NewCommand.php` with the native PHP `ZipArchive` class, which is the standard tool for ZIP manipulation in PHP/Symfony projects. The implementation includes:
1. Importing the `ZipArchive` class.
2. Creating the temporary extraction directory.
3. Opening the profile ZIP file and extracting its contents to the temporary directory.
4. Correctly setting the success flag for the existing logic that handles the extracted files.

The logic has been verified with a standalone script to ensure it correctly extracts files and identifies the root directory of the profile.

---
*PR created automatically by Jules for task [7746076139456589807](https://jules.google.com/task/7746076139456589807) started by @flydev-fr*