### PR TITLE
⚡ [performance improvement] Optimize N+1 user role save operations

### DIFF
--- a/src/Helpers/PwUserTools.php
+++ b/src/Helpers/PwUserTools.php
@@ -94,8 +94,6 @@ class PwUserTools extends PwConnector {
         $editedUser->removeRole($role->name);
       }
     }
-    $editedUser->save();
-
     // remove existing roles
     if ($reset === true) {
       foreach ($editedUser->roles as $role) {
@@ -109,8 +107,9 @@ class PwUserTools extends PwConnector {
       $this->checkIfRoleExists($role, $output);
 
       $editedUser->addRole($role);
-      $editedUser->save();
     }
+
+    $editedUser->save();
 
     return $editedUser;
   }


### PR DESCRIPTION
### 💡 What:
The optimization reduces the number of database write operations in `PwUserTools::attachRolesToUser` by moving the `$editedUser->save()` call out of the `foreach` loop that iterates over roles. It also removes an intermediate redundant `save()` call.

### 🎯 Why:
The original code had an N+1 issue where every role added or removed triggered a separate database save operation. This is inefficient, especially when attaching many roles at once. Consolidating these into a single `save()` at the end of the method is more efficient and ensures atomicity for the role updates.

### 📊 Measured Improvement:
Using a mock-based performance script, I established a baseline of **4 save calls** for a sample of 3 roles (1 for initial cleanup + 3 for additions). After the optimization, the number of save calls was reduced to **exactly 1**, regardless of the number of roles processed. This represents a significant reduction in database I/O for this code path.

**Verification Results:**
- **Baseline:** 4 saves for 3 roles.
- **Optimized:** 1 save for 3 roles.
- **Improvement:** 75% reduction in save operations for this scenario (and more for larger role sets).


---
*PR created automatically by Jules for task [6580931905620183491](https://jules.google.com/task/6580931905620183491) started by @flydev-fr*